### PR TITLE
Feature/rails 5 1 compatibility

### DIFF
--- a/lib/delegates_attributes_to.rb
+++ b/lib/delegates_attributes_to.rb
@@ -135,8 +135,8 @@ module DelegatesAttributesTo
           result.merge! delegated_attribute => association_changed_attributes[attribute]
         end
         changed_attributes = super
-        changed_attributes.merge!(result)
-        changed_attributes
+        result.merge! changed_attributes
+        result
       end
   end
 end


### PR DESCRIPTION
Removes `alias_method_chain` in favour of `prepend` as `alias_method_chain` has been deprecated in 5.1